### PR TITLE
Sometimes the $data argument of the checkResponse() method has a string type

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -70,8 +70,9 @@ class Provider extends AbstractProvider
     protected function checkResponse(ResponseInterface $response, $data)
     {
         $statusCode = $response->getStatusCode();
-        if ($statusCode !== 200 || isset($data['message'])) {
-            throw new IdentityProviderException($data['message'] ?: $response->getReasonPhrase(), $statusCode, $response);
+        if ($statusCode !== 200) {
+            $message = isset($data['message']) ? $data['message'] : $response->getReasonPhrase();
+            throw new IdentityProviderException($message, $statusCode, $response);
         }
     }
 

--- a/tests/ProviderTest.php
+++ b/tests/ProviderTest.php
@@ -121,6 +121,28 @@ class ProviderTest extends \PHPUnit_Framework_TestCase
         $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 
+    /**
+     * @expectedException \Ely\OAuth2\Client\Exception\IdentityProviderException
+     * @expectedExceptionMessage Bad Gateway
+     */
+    public function testExceptionThrownOnIncorrectContentType()
+    {
+        /** @var m\Mock|ResponseInterface $postResponse */
+        $postResponse = m::mock(ResponseInterface::class);
+        $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'text/html; charset=UTF-8']);
+        $postResponse->shouldReceive('getBody')->andReturn('html content');
+        $postResponse->shouldReceive('getStatusCode')->andReturn(502);
+        $postResponse->shouldReceive('getReasonPhrase')->andReturn('Bad Gateway');
+
+        /** @var m\Mock|ClientInterface $client */
+        $client = m::mock(ClientInterface::class);
+        $client->shouldReceive('send')
+            ->times(1)
+            ->andReturn($postResponse);
+        $this->provider->setHttpClient($client);
+        $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+    }
+
     public function testGetResourceOwner()
     {
         /** @var m\Mock|ResponseInterface $postResponse */


### PR DESCRIPTION
If the OAuth server responds with 502 status and non-json content, the parseResponse() method of the AbstractProvider class returns a string instead of an array.

Fixes #3